### PR TITLE
fix: keyCode 属性已弃用，使用 key 替代

### DIFF
--- a/src/common/keyCode.ts
+++ b/src/common/keyCode.ts
@@ -1,3 +1,3 @@
-const KeyCode = { S: 83 };
+const KeyCode = { S: 's' };
 
 export default KeyCode;

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -51,8 +51,8 @@ export default (props: IEditorProps) => {
 
   useEffect(() => {
     const listener = (event: KeyboardEvent) => {
-      const { keyCode, ctrlKey, metaKey } = event;
-      if (keyCode === keydown.S && (ctrlKey || metaKey)) {
+      const { key, ctrlKey, metaKey } = event;
+      if (key === keydown.S && (ctrlKey || metaKey)) {
         event.preventDefault();
         handleFormatter();
       }


### PR DESCRIPTION
https://developer.mozilla.org/zh-CN/docs/Web/API/KeyboardEvent/keyCode